### PR TITLE
不要なテストコードを削除

### DIFF
--- a/tests/unit/login.test.tsx
+++ b/tests/unit/login.test.tsx
@@ -7,14 +7,9 @@ import SignIn from '../../src/pages/SignIn';
 describe('ログイン画面コンポーネント', () => {
   it('メールアドレスとパスワードの入力フォームが表示されるログイン画面のレンダリング', () => {
     render(<SignIn />);
-    const emailInputLabel = screen.getByText('メールアドレス');
-    expect(emailInputLabel).toBeInTheDocument();
 
     const emailInput = screen.getByLabelText('メールアドレス');
     expect(emailInput).toBeInTheDocument();
-
-    const passwordInputLabel = screen.getByText('パスワード');
-    expect(passwordInputLabel).toBeInTheDocument();
 
     const passwordInput = screen.getByLabelText('パスワード');
     expect(passwordInput).toBeInTheDocument();


### PR DESCRIPTION
getByLabelTextは、labelと紐づいてるinput要素の両方を確認できるため、getByTextでテキストを確認するテストは不要なので削除しました。