### PR TITLE
Station7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-foundation-3",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.0",
         "@reduxjs/toolkit": "^2.2.7",
         "@unocss/reset": "^0.62.3",
         "axios": "^1.7.7",
@@ -941,6 +942,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
+      "integrity": "sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-hook-form": "^7.53.0",
         "react-redux": "^9.1.2",
         "react-router": "^6.26.2",
-        "react-router-dom": "^6.26.2"
+        "react-router-dom": "^6.26.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -8095,6 +8096,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tscheck": "tsc --noEmit --skipLibCheck --project tsconfig.app.json"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@reduxjs/toolkit": "^2.2.7",
     "@unocss/reset": "^0.62.3",
     "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-hook-form": "^7.53.0",
     "react-redux": "^9.1.2",
     "react-router": "^6.26.2",
-    "react-router-dom": "^6.26.2"
+    "react-router-dom": "^6.26.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/pages/userProfile/EditProfile.tsx
+++ b/src/pages/userProfile/EditProfile.tsx
@@ -6,6 +6,7 @@ import { fetchUserData } from '../../features/user/userSlice';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import imageCompression from '../../utils/imageCompression';
 
 const editProfileSchema = z.object({
   name: z
@@ -57,11 +58,8 @@ const EditProfile = () => {
     }
   }, [userData, reset]);
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setValue('iconUrl', file, { shouldValidate: true });
-    }
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    imageCompression(e, setValue);
   };
 
   const onSubmit: SubmitHandler<EditProfile> = async (data) => {
@@ -84,7 +82,7 @@ const EditProfile = () => {
               type="file"
               id="iconUrl"
               accept=".jpg, .jpeg, .png"
-              {...register('iconUrl', { onChange: handleFileChange })}
+              {...register('iconUrl', { onChange: handleImageChange })}
               className="hidden"
             />
             {iconUrl && (

--- a/src/pages/userProfile/EditProfile.tsx
+++ b/src/pages/userProfile/EditProfile.tsx
@@ -1,17 +1,109 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState, useAppDispatch } from '../../app/store';
+import { useCookies } from 'react-cookie';
+import { fetchUserData } from '../../features/user/userSlice';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, SubmitHandler } from 'react-hook-form';
+
+const editProfileSchema = z.object({
+  name: z
+    .string({
+      required_error: 'ユーザー名は必須です',
+    })
+    .min(1, {
+      message: 'ユーザー名は1文字以上で入力してください',
+    }),
+  iconUrl: z.union([z.string(), z.instanceof(File)]),
+});
+
+type EditProfile = z.infer<typeof editProfileSchema>;
+
 const EditProfile = () => {
+  const userData = useSelector((state: RootState) => state.user.userData);
+  const fetchDispatch = useAppDispatch();
+  const [cookies] = useCookies(['token']);
+  const token = cookies.token;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, errors },
+    setValue,
+    watch,
+    reset,
+  } = useForm<EditProfile>({
+    mode: 'onBlur',
+    resolver: zodResolver(editProfileSchema),
+    defaultValues: {
+      name: userData?.name,
+      iconUrl: userData?.iconUrl,
+    },
+  });
+
+  const iconUrl = watch('iconUrl') as string | File | undefined;
+
+  useEffect(() => {
+    fetchDispatch(fetchUserData(token));
+  }, [fetchDispatch, token]);
+
+  useEffect(() => {
+    if (userData) {
+      reset({
+        name: userData.name,
+        iconUrl: userData.iconUrl,
+      });
+    }
+  }, [userData, reset]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setValue('iconUrl', file, { shouldValidate: true });
+    }
+  };
+
+  const onSubmit: SubmitHandler<EditProfile> = async (data) => {
+    console.log(data);
+  };
+
   return (
     <div>
       <main>
         <h1>プロフィールを編集</h1>
-        <form>
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <div>
             <label htmlFor="name">ユーザー名</label>
-            <input type="text" id="name" name="name" />
+            <input type="text" id="name" {...register('name')} />
+            {errors.name && <p>{errors.name.message}</p>}
           </div>
           <div>
             <label htmlFor="iconUrl">アイコン画像</label>
-            <input type="file" id="iconUrl" name="iconUrl" />
+            <input
+              type="file"
+              id="iconUrl"
+              accept=".jpg, .jpeg, .png"
+              {...register('iconUrl', { onChange: handleFileChange })}
+              className="hidden"
+            />
+            {iconUrl && (
+              <img
+                src={
+                  typeof iconUrl === 'string'
+                    ? iconUrl
+                    : iconUrl instanceof File
+                      ? URL.createObjectURL(iconUrl)
+                      : ''
+                }
+                alt="ユーザー画像プレビュー"
+              />
+            )}
+            {errors.iconUrl && <p>{errors.iconUrl.message}</p>}
           </div>
+          <button type="submit" disabled={!isValid}>
+            変更を保存
+          </button>
         </form>
       </main>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface Book {
 
 export interface User {
   name: string;
-  iconUrl: string | undefined;
+  iconUrl: File | string | undefined;
 }
 export interface OffsetState {
   offset: number;

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -1,0 +1,42 @@
+import Compressor from 'compressorjs';
+import { UseFormSetValue } from 'react-hook-form';
+
+type FormValues = {
+  iconUrl: string | File;
+  name: string;
+};
+
+const imageCompression = (
+  e: React.ChangeEvent<HTMLInputElement>,
+  setValue: UseFormSetValue<FormValues>
+) => {
+  const file = e.target.files?.[0];
+
+  if (!file) return;
+
+  let quality;
+
+  if (file.size > 5 * 1024 * 1024) {
+    quality = 0.4;
+  } else if (file.size < 2 * 1024 * 1024) {
+    quality = 0.6;
+  } else {
+    quality = 0.8;
+  }
+
+  new Compressor(file, {
+    quality,
+    success: (compressedFile) => {
+      const newFile = new File([compressedFile], file.name, {
+        type: compressedFile.type,
+        lastModified: Date.now(),
+      });
+      setValue('iconUrl', newFile, { shouldValidate: true });
+    },
+    error: (error) => {
+      console.error(error.message);
+    },
+  });
+};
+
+export default imageCompression;


### PR DESCRIPTION
【Station7:ユーザー情報編集画面を作ろう】
『クリア条件』
- ユーザー情報編集画面を作成する。（/profile）
- 一覧画面のヘッダーにユーザー情報編集画面へのリンクを表示する。
- フォームには登録済みのユーザー情報が入力されている状態にする。
- ユーザー情報更新 API を使ってユーザー情報を更新できるようにする。

『今回の実装内容』
- zodとuseFormを使って入力フォームを作成
- 画像圧縮関数をjsファイルに作成して再利用可能にする
- ユーザー名やアイコン画像を変更してAPIにリクエストが成功するとホーム画面に遷移する処理を実装