### PR TITLE
Station8

### DIFF
--- a/src/pages/auth/authSlice.ts
+++ b/src/pages/auth/authSlice.ts
@@ -15,8 +15,11 @@ export const authSlice = createSlice({
     signIn: (state) => {
       state.isAuthenticated = true;
     },
+    signOut: (state) => {
+      state.isAuthenticated = false;
+    },
   },
 });
 
-export const { signIn } = authSlice.actions;
+export const { signIn, signOut } = authSlice.actions;
 export default authSlice.reducer;

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -6,17 +6,33 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../app/store';
 import { Link } from 'react-router-dom';
 import UserAvatar from '../../features/user/UserAvatar';
+import { signOut } from '../auth/authSlice';
+import { useCookies } from 'react-cookie';
+import { useNavigate } from 'react-router-dom';
 
 const Home = () => {
   const isAuthenticated = useSelector((state: RootState) => state.auth.isAuthenticated);
   const dispatch = useDispatch();
+  const [_cookies, _setCookie, removeCookie] = useCookies(['token']);
+  const navigate = useNavigate();
+
+  const handleSignOut = () => {
+    dispatch(signOut());
+    removeCookie('token');
+    navigate('/login');
+  };
 
   return (
     <main className="flex min-h-full flex-col px-6 py-12 lg:px-8">
       <Header>
         <div className="flex justify-end">
           {isAuthenticated ? (
-            <Link to="/profile"><UserAvatar /></Link>
+            <div>
+              <Link to="/profile">
+                <UserAvatar />
+              </Link>
+              <button onClick={handleSignOut}>ログアウト</button>
+            </div>
           ) : (
             <Link
               to="/login"


### PR DESCRIPTION
【Station8:ログアウト処理を実装しよう】

-クリア条件-
- ログイン時はヘッダーにログアウトボタンを表示させる。
- ログアウト時にブラウザに保存した認証トークンを削除する。
- ログアウト後はログイン画面にリダイレクトする。



-今回の実装内容-
1. HeaderのコンポーネントにButtonタグをChildrenとして渡す
2. authSliceにログアウトのreducerを追加（isAuthenticatedのStateをfalseにする処理）
3. ボタンをクリックするとクッキーに保存しているトークンを削除、dispatchでログアウトアクションを実行させる
4. navigateメソッドを使ってログイン画面にリダイレクトさせる