### PR TITLE
ホバーした時にリンクのテキスト幅に合わせてボーダー線を表示させるstyleを追加

### DIFF
--- a/src/features/bookReviews/ReviewCard.tsx
+++ b/src/features/bookReviews/ReviewCard.tsx
@@ -11,13 +11,15 @@ const ReviewCard = (props: ReviewCardProps) => {
   return (
     <li className="border border-gray-300 rounded-md pt-2 px-2">
       <div className="border-b border-gray-300 py-2">
-        <Link
-          to={book.url}
-          target="_blank"
-          className="text-xl text-gray-900 line-clamp-2 hover:text-blue-600 duration-300"
-        >
-          {book.title}
-        </Link>
+        <div className="inline-block hover:border-b hover:border-blue-600">
+          <Link
+            to={book.url}
+            target="_blank"
+            className="text-xl text-gray-900 line-clamp-2 hover:text-blue-600 duration-300"
+          >
+            {book.title}
+          </Link>
+        </div>
       </div>
       <p className="px-2 pt-2 text-sm mt-1 text-gray-900 truncate">{book.detail}</p>
       <p className=" px-2 py-3 text-sm text-gray-900">レビュワー：{book.reviewer}</p>


### PR DESCRIPTION
-今回の実装内容-
- ホバーした時にリンクのテキスト幅に合わせてボーダー線を表示させるstyleを追加

リンクのテキストをホバーした時にテキストの幅に合わせて青いボーダー線を表示させたいが、すでにLinkタグでは2行以上の書籍タイトルは[...]と表示させるために「line-clamp-2」を使っていて、Linkタグでdisplayを操作すると「line-clamp-2」が適用されなくなってしまうのでdivタグにdisplayとborderのCSSを追加することで解決。

<img width="434" alt="スクリーンショット 2024-10-14 16 16 53" src="https://github.com/user-attachments/assets/a8856db1-53c9-4c96-b54c-3c593f5b09ce">
<img width="435" alt="スクリーンショット 2024-10-14 16 16 27" src="https://github.com/user-attachments/assets/d1da76cb-00d4-420a-816a-202a8a1fa5db">

